### PR TITLE
feat: rely on tryfrom trait for Duration conversions

### DIFF
--- a/src/gax/src/request_parameter.rs
+++ b/src/gax/src/request_parameter.rs
@@ -76,7 +76,7 @@ impl RequestParameter for bytes::Bytes {
 
 impl RequestParameter for wkt::Duration {
     fn format(&self) -> Result {
-        Ok(self.to_json())
+        Ok(String::from(self))
     }
 }
 

--- a/src/wkt/src/duration.rs
+++ b/src/wkt/src/duration.rs
@@ -164,6 +164,29 @@ impl Duration {
     }
 }
 
+/// Convert from [Duration] to String representation
+impl std::convert::From<&Duration> for String {
+    fn from(duration: &Duration) -> String {
+        let sign = if duration.seconds < 0 || duration.nanos < 0 {
+            "-"
+        } else {
+            ""
+        };
+        if duration.nanos == 0 {
+            return format!("{sign}{}s", duration.seconds.abs());
+        }
+        if duration.seconds == 0 {
+            let ns = format!("{:09}", duration.nanos.abs());
+            return format!("{sign}0.{}s", ns.trim_end_matches('0'));
+        }
+        format!(
+            "{sign}{}.{:09}s",
+            duration.seconds.abs(),
+            duration.nanos.abs()
+        )
+    }
+}
+
 /// Convert from String representation to [Duration]
 impl std::convert::TryFrom<&str> for Duration {
     type Error = DurationError;
@@ -195,29 +218,6 @@ impl std::convert::TryFrom<&str> for Duration {
             .unwrap_or(0);
 
         Duration::new(sign * seconds, sign as i32 * nanos)
-    }
-}
-
-/// Convert from [Duration] to String representation
-impl std::convert::From<&Duration> for String {
-    fn from(duration: &Duration) -> String {
-        let sign = if duration.seconds < 0 || duration.nanos < 0 {
-            "-"
-        } else {
-            ""
-        };
-        if duration.nanos == 0 {
-            return format!("{sign}{}s", duration.seconds.abs());
-        }
-        if duration.seconds == 0 {
-            let ns = format!("{:09}", duration.nanos.abs());
-            return format!("{sign}0.{}s", ns.trim_end_matches('0'));
-        }
-        format!(
-            "{sign}{}.{:09}s",
-            duration.seconds.abs(),
-            duration.nanos.abs()
-        )
     }
 }
 

--- a/src/wkt/tests/duration.rs
+++ b/src/wkt/tests/duration.rs
@@ -73,6 +73,24 @@ fn compare() {
 }
 
 #[test]
+fn from_str_duration() -> Result {
+    let str_duration = "10s";
+    let got = Duration::try_from(str_duration);
+    assert_eq!(got, Duration::new(10, 0));
+
+    Ok(())
+}
+
+#[test]
+fn from_duration_str() -> Result {
+    let duration = Duration::new(10, 0)?;
+    let got = String::from(&duration);
+    assert_eq!(got, "10s".to_string());
+
+    Ok(())
+}
+
+#[test]
 fn from_std_time_duration() -> Result {
     let std_d = std::time::Duration::new(123, 456789012);
     let got = Duration::try_from(std_d)?;


### PR DESCRIPTION
For https://github.com/googleapis/google-cloud-rust/issues/423. This PR only focuses on conversions between String representations and Durations. 

Verified locally with: `cargo fmt && cargo clippy -- --deny warnings && cargo test`